### PR TITLE
Add experimental MongoDB driver adapter

### DIFF
--- a/packages/adapter-mongodb/README.md
+++ b/packages/adapter-mongodb/README.md
@@ -1,0 +1,5 @@
+# @prisma/adapter-mongodb
+
+Experimental driver adapter for using the official `mongodb` package with Prisma.
+
+This adapter is not officially supported and is provided as an example. It manages MongoDB transactions using `AsyncLocalStorage` so that queries run inside a transaction automatically use the correct session.

--- a/packages/adapter-mongodb/helpers/build.ts
+++ b/packages/adapter-mongodb/helpers/build.ts
@@ -1,0 +1,4 @@
+import { build } from '../../../helpers/compile/build'
+import { adapterConfig } from '../../../helpers/compile/configs'
+
+void build(adapterConfig)

--- a/packages/adapter-mongodb/package.json
+++ b/packages/adapter-mongodb/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@prisma/adapter-mongodb",
+  "version": "0.0.0",
+  "description": "Experimental Prisma driver adapter for mongodb",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+      "import": { "types": "./dist/index.d.mts", "default": "./dist/index.mjs" }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/adapter-mongodb"
+  },
+  "scripts": {
+    "dev": "DEV=true tsx helpers/build.ts",
+    "build": "tsx helpers/build.ts"
+  },
+  "files": ["dist", "README.md"],
+  "keywords": [],
+  "author": "Prisma",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "dependencies": {
+    "@prisma/driver-adapter-utils": "workspace:*",
+    "mongodb": "5.7.0"
+  },
+  "peerDependencies": {
+    "mongodb": ">=5"
+  }
+}

--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -1,0 +1,1 @@
+export { PrismaMongoAdapterFactory as PrismaMongo } from './mongodb'

--- a/packages/adapter-mongodb/src/mongodb.ts
+++ b/packages/adapter-mongodb/src/mongodb.ts
@@ -1,0 +1,120 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { MongoClient, Db, ClientSession } from 'mongodb'
+import {
+  type SqlDriverAdapter,
+  type SqlDriverAdapterFactory,
+  type SqlQueryable,
+  type SqlQuery,
+  type SqlResultSet,
+  type Transaction,
+  type TransactionOptions,
+  type IsolationLevel,
+  type ConnectionInfo,
+} from '@prisma/driver-adapter-utils'
+import { Debug, DriverAdapterError } from '@prisma/driver-adapter-utils'
+
+import { name as packageName } from '../package.json'
+
+const debug = Debug('prisma:driver-adapter:mongodb')
+
+interface TransactionContext {
+  db: Db
+  session: ClientSession
+}
+
+const txStorage = new AsyncLocalStorage<TransactionContext>()
+
+type StdClient = MongoClient
+
+class MongoQueryable implements SqlQueryable {
+  readonly provider = 'postgres' as SqlDriverAdapter['provider'] // placeholder
+  readonly adapterName = packageName
+
+  constructor(protected readonly db: Db) {}
+
+  async queryRaw(query: SqlQuery): Promise<SqlResultSet> {
+    const tag = '[js::query_raw]'
+    debug('%s %o', tag, query)
+
+    const cmd = typeof query.sql === 'string' ? JSON.parse(query.sql) : query.sql
+    const session = txStorage.getStore()?.session
+
+    const result = await this.db.command(cmd, { session })
+
+    return {
+      columnNames: [],
+      columnTypes: [],
+      rows: [result],
+    }
+  }
+
+  async executeRaw(query: SqlQuery): Promise<number> {
+    const r = await this.queryRaw(query)
+    return r.rows.length
+  }
+}
+
+class MongoTransaction extends MongoQueryable implements Transaction {
+  constructor(db: Db, private session: ClientSession, readonly options: TransactionOptions) {
+    super(db)
+  }
+
+  async commit(): Promise<void> {
+    debug('[js::commit]')
+    await this.session.commitTransaction()
+    this.session.endSession()
+  }
+
+  async rollback(): Promise<void> {
+    debug('[js::rollback]')
+    await this.session.abortTransaction()
+    this.session.endSession()
+  }
+}
+
+export type PrismaMongoOptions = {
+  dbName: string
+}
+
+export class PrismaMongoAdapter extends MongoQueryable implements SqlDriverAdapter {
+  constructor(private readonly client: StdClient, private readonly options: PrismaMongoOptions) {
+    super(client.db(options.dbName))
+  }
+
+  executeScript(_script: string): Promise<void> {
+    throw new Error('Not implemented yet')
+  }
+
+  async startTransaction(_isolationLevel?: IsolationLevel): Promise<Transaction> {
+    const session = this.client.startSession()
+    await session.startTransaction()
+    const tx = new MongoTransaction(this.client.db(this.options.dbName), session, { usePhantomQuery: false })
+    txStorage.enterWith({ db: this.client.db(this.options.dbName), session })
+    return tx
+  }
+
+  getConnectionInfo(): ConnectionInfo {
+    return { schemaName: this.options.dbName }
+  }
+
+  async dispose(): Promise<void> {
+    await this.client.close()
+  }
+}
+
+export class PrismaMongoAdapterFactory implements SqlDriverAdapterFactory {
+  readonly provider = 'postgres' as SqlDriverAdapter['provider'] // placeholder
+  readonly adapterName = packageName
+
+  constructor(private readonly options: { url: string; dbName: string }) {}
+
+  async connect(): Promise<SqlDriverAdapter> {
+    const client = new MongoClient(this.options.url)
+    try {
+      await client.connect()
+      return new PrismaMongoAdapter(client, { dbName: this.options.dbName })
+    } catch (e) {
+      throw new DriverAdapterError({ kind: 'GenericJs', id: 0 })
+    }
+  }
+}

--- a/packages/adapter-mongodb/tsconfig.build.json
+++ b/packages/adapter-mongodb/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.regular.json",
+  "compilerOptions": {
+    "outDir": "declaration"
+  },
+  "include": ["src"]
+}

--- a/packages/adapter-mongodb/tsconfig.json
+++ b/packages/adapter-mongodb/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- add @prisma/adapter-mongodb package
- implement experimental Mongo adapter using `mongodb` and AsyncLocalStorage

## Testing
- `pnpm install --filter @prisma/adapter-mongodb` *(fails: cannot find module in postinstall)*

------
https://chatgpt.com/codex/tasks/task_b_68513d580a1483209cad4de1c1bd70ec